### PR TITLE
DIV-6825-Search-results-are-displayed-in-alphabetical-order

### DIFF
--- a/__tests__/mockResponseBody.json
+++ b/__tests__/mockResponseBody.json
@@ -43,5 +43,125 @@
     ],
     "name": "Kassulke Inc",
     "organisationIdentifier": "24-3701590"
+  },
+  {
+    "contactInformation": [
+      {
+        "addressLine1": "1 Trasna way",
+        "addressLine2": "Lurgan",
+        "addressLine3": "",
+        "country": "United Kingdom",
+        "county": "Armagh",
+        "postCode": "BT25 545",
+        "townCity": "Craigavon"
+      }
+    ],
+    "name": "B Org",
+    "organisationIdentifier": "21-3701590"
+  },
+  {
+    "contactInformation": [
+      {
+        "addressLine1": "10 Lakeview",
+        "addressLine2": "Crumlin",
+        "addressLine3": "",
+        "country": "United Kingdom",
+        "county": "Down",
+        "postCode": "BT21 525",
+        "townCity": "Ballymena"
+      }
+    ],
+    "name": "Z and Sons",
+    "organisationIdentifier": "25-3701590"
+  },
+  {
+    "contactInformation": [
+      {
+        "addressLine1": "24 Sandbank rd",
+        "addressLine2": "Sandbank",
+        "addressLine3": "",
+        "country": "United Kingdom",
+        "county": "Down",
+        "postCode": "BT21 525",
+        "townCity": "Galway"
+      }
+    ],
+    "name": "X Org",
+    "organisationIdentifier": "24-3701590"
+  },
+  {
+    "contactInformation": [
+      {
+        "addressLine1": "24 Sandbank rd",
+        "addressLine2": "Sandbank",
+        "addressLine3": "",
+        "country": "United Kingdom",
+        "county": "Down",
+        "postCode": "BT21 525",
+        "townCity": "Galway"
+      }
+    ],
+    "name": "1 Org",
+    "organisationIdentifier": "24-3701590"
+  },
+  {
+    "contactInformation": [
+      {
+        "addressLine1": "24 Sandbank rd",
+        "addressLine2": "Sandbank",
+        "addressLine3": "",
+        "country": "United Kingdom",
+        "county": "Down",
+        "postCode": "BT21 525",
+        "townCity": "Galway"
+      }
+    ],
+    "name": "2 Org",
+    "organisationIdentifier": "24-3701590"
+  },
+  {
+    "contactInformation": [
+      {
+        "addressLine1": "24 Sandbank rd",
+        "addressLine2": "Sandbank",
+        "addressLine3": "",
+        "country": "United Kingdom",
+        "county": "Down",
+        "postCode": "BT21 525",
+        "townCity": "Galway"
+      }
+    ],
+    "name": "9 Org",
+    "organisationIdentifier": "24-3701590"
+  },
+  {
+    "contactInformation": [
+      {
+        "addressLine1": "24 Sandbank rd",
+        "addressLine2": "Sandbank",
+        "addressLine3": "",
+        "country": "United Kingdom",
+        "county": "Down",
+        "postCode": "BT21 525",
+        "townCity": "Galway"
+      }
+    ],
+    "name": "0 Org",
+    "organisationIdentifier": "24-3701590"
+  },
+  {
+    "contactInformation": [
+      {
+        "addressLine1": "24 Sandbank rd",
+        "addressLine2": "Sandbank",
+        "addressLine3": "",
+        "country": "United Kingdom",
+        "county": "Down",
+        "postCode": "BT21 525",
+        "townCity": "Galway"
+      }
+    ],
+    "name": "* Org",
+    "organisationIdentifier": "24-3701590"
   }
 ]

--- a/__tests__/mockResponseBody.json
+++ b/__tests__/mockResponseBody.json
@@ -12,7 +12,7 @@
       }
     ],
     "name": "Ernser Inc",
-    "organisationIdentifier": "21-3701590"
+    "organisationIdentifier": "21-1111111"
   },
   {
     "contactInformation": [
@@ -27,7 +27,7 @@
       }
     ],
     "name": "Zboncak and Sons",
-    "organisationIdentifier": "25-3701590"
+    "organisationIdentifier": "22-2222222"
   },
   {
     "contactInformation": [
@@ -42,67 +42,67 @@
       }
     ],
     "name": "Kassulke Inc",
-    "organisationIdentifier": "24-3701590"
+    "organisationIdentifier": "23-3333333"
   },
   {
     "contactInformation": [
       {
-        "addressLine1": "1 Trasna way",
-        "addressLine2": "Lurgan",
+        "addressLine1": "1 This is the way",
+        "addressLine2": "London",
         "addressLine3": "",
         "country": "United Kingdom",
-        "county": "Armagh",
-        "postCode": "BT25 545",
-        "townCity": "Craigavon"
+        "county": "Westminster",
+        "postCode": "XW16 5AA",
+        "townCity": "London"
       }
     ],
     "name": "B Org",
-    "organisationIdentifier": "21-3701590"
+    "organisationIdentifier": "24-4444444"
   },
   {
     "contactInformation": [
       {
-        "addressLine1": "10 Lakeview",
+        "addressLine1": "12 Lakeview",
         "addressLine2": "Crumlin",
         "addressLine3": "",
         "country": "United Kingdom",
         "county": "Down",
-        "postCode": "BT21 525",
+        "postCode": "BT21 G25",
         "townCity": "Ballymena"
       }
     ],
     "name": "Z and Sons",
-    "organisationIdentifier": "25-3701590"
+    "organisationIdentifier": "25-5555555"
   },
   {
     "contactInformation": [
       {
-        "addressLine1": "24 Sandbank rd",
-        "addressLine2": "Sandbank",
+        "addressLine1": "24 Mountain rd",
+        "addressLine2": "Hideban,",
         "addressLine3": "",
         "country": "United Kingdom",
         "county": "Down",
-        "postCode": "BT21 525",
-        "townCity": "Galway"
+        "postCode": "BT18 7DU",
+        "townCity": "Belfast"
       }
     ],
     "name": "X Org",
-    "organisationIdentifier": "24-3701590"
+    "organisationIdentifier": "26-6666666"
   },
   {
     "contactInformation": [
       {
-        "addressLine1": "24 Sandbank rd",
-        "addressLine2": "Sandbank",
+        "addressLine1": "64 Zoo lane",
+        "addressLine2": "On the Hikk",
         "addressLine3": "",
         "country": "United Kingdom",
         "county": "Down",
-        "postCode": "BT21 525",
+        "postCode": "BT21 6JE",
         "townCity": "Galway"
       }
     ],
     "name": "1 Org",
-    "organisationIdentifier": "24-3701590"
+    "organisationIdentifier": "27-7777777"
   },
   {
     "contactInformation": [
@@ -117,7 +117,7 @@
       }
     ],
     "name": "2 Org",
-    "organisationIdentifier": "24-3701590"
+    "organisationIdentifier": "24-1238393"
   },
   {
     "contactInformation": [
@@ -132,7 +132,7 @@
       }
     ],
     "name": "9 Org",
-    "organisationIdentifier": "24-3701590"
+    "organisationIdentifier": "24-1238333"
   },
   {
     "contactInformation": [
@@ -147,7 +147,7 @@
       }
     ],
     "name": "0 Org",
-    "organisationIdentifier": "24-3701590"
+    "organisationIdentifier": "24-4827328"
   },
   {
     "contactInformation": [
@@ -162,6 +162,6 @@
       }
     ],
     "name": "* Org",
-    "organisationIdentifier": "24-3701590"
+    "organisationIdentifier": "24-2847729"
   }
 ]

--- a/__tests__/organisationClient.ts
+++ b/__tests__/organisationClient.ts
@@ -156,6 +156,48 @@ describe('organisationClient', () => {
       })
     });
 
+    test('it should return a list of organisations in alphabetical order (Ascending)', () => {
+      nock(mockUrl)
+          .get(`/${mockStatus}?address=true`)
+          .reply(200, fs.readFileSync(path.join(__dirname, 'mockResponseBody.json')))
+
+      return organisationClient.getOrganisationByName(mockStatus, 'inc')
+          .then(response => {
+            expect(response).toEqual([
+              {
+                "contactInformation": [
+                  {
+                    "addressLine1": "1 Trasna way",
+                    "addressLine2": "Lurgan",
+                    "addressLine3": "",
+                    "country": "United Kingdom",
+                    "county": "Armagh",
+                    "postCode": "BT25 545",
+                    "townCity": "Craigavon"
+                  }
+                ],
+                "name": "Ernser Inc",
+                "organisationIdentifier": "21-3701590"
+              },
+              {
+                "contactInformation": [
+                  {
+                    "addressLine1": "24 Sandbank rd",
+                    "addressLine2": "Sandbank",
+                    "addressLine3": "",
+                    "country": "United Kingdom",
+                    "county": "Down",
+                    "postCode": "BT21 525",
+                    "townCity": "Galway"
+                  }
+                ],
+                "name": "Kassulke Inc",
+                "organisationIdentifier": "24-3701590"
+              }
+            ]);
+          })
+    });
+
     test('it should return an empty list if no organisations include organiation name', () => {
       nock(mockUrl)
       .get(`/${mockStatus}?address=true`)

--- a/__tests__/organisationClient.ts
+++ b/__tests__/organisationClient.ts
@@ -393,7 +393,7 @@ describe('organisationClient', () => {
           })
     });
 
-    test('it should return an empty list if no organisations include organiation name', () => {
+    test('it should return an empty list if no organisations include organisation name', () => {
       nock(mockUrl)
       .get(`/${mockStatus}?address=true`)
       .reply(200, fs.readFileSync(path.join(__dirname, 'mockResponseBody.json')))

--- a/__tests__/organisationClient.ts
+++ b/__tests__/organisationClient.ts
@@ -66,6 +66,126 @@ describe('organisationClient', () => {
               ],
               "name": "Kassulke Inc",
               "organisationIdentifier": "24-3701590"
+            },
+            {
+              "contactInformation": [
+                {
+                  "addressLine1": "1 Trasna way",
+                  "addressLine2": "Lurgan",
+                  "addressLine3": "",
+                  "country": "United Kingdom",
+                  "county": "Armagh",
+                  "postCode": "BT25 545",
+                  "townCity": "Craigavon"
+                }
+              ],
+              "name": "B Org",
+              "organisationIdentifier": "21-3701590"
+            },
+            {
+              "contactInformation": [
+                {
+                  "addressLine1": "10 Lakeview",
+                  "addressLine2": "Crumlin",
+                  "addressLine3": "",
+                  "country": "United Kingdom",
+                  "county": "Down",
+                  "postCode": "BT21 525",
+                  "townCity": "Ballymena"
+                }
+              ],
+              "name": "Z and Sons",
+              "organisationIdentifier": "25-3701590"
+            },
+            {
+              "contactInformation": [
+                {
+                  "addressLine1": "24 Sandbank rd",
+                  "addressLine2": "Sandbank",
+                  "addressLine3": "",
+                  "country": "United Kingdom",
+                  "county": "Down",
+                  "postCode": "BT21 525",
+                  "townCity": "Galway"
+                }
+              ],
+              "name": "X Org",
+              "organisationIdentifier": "24-3701590"
+            },
+            {
+              "contactInformation": [
+                {
+                  "addressLine1": "24 Sandbank rd",
+                  "addressLine2": "Sandbank",
+                  "addressLine3": "",
+                  "country": "United Kingdom",
+                  "county": "Down",
+                  "postCode": "BT21 525",
+                  "townCity": "Galway"
+                }
+              ],
+              "name": "1 Org",
+              "organisationIdentifier": "24-3701590"
+            },
+            {
+              "contactInformation": [
+                {
+                  "addressLine1": "24 Sandbank rd",
+                  "addressLine2": "Sandbank",
+                  "addressLine3": "",
+                  "country": "United Kingdom",
+                  "county": "Down",
+                  "postCode": "BT21 525",
+                  "townCity": "Galway"
+                }
+              ],
+              "name": "2 Org",
+              "organisationIdentifier": "24-3701590"
+            },
+            {
+              "contactInformation": [
+                {
+                  "addressLine1": "24 Sandbank rd",
+                  "addressLine2": "Sandbank",
+                  "addressLine3": "",
+                  "country": "United Kingdom",
+                  "county": "Down",
+                  "postCode": "BT21 525",
+                  "townCity": "Galway"
+                }
+              ],
+              "name": "9 Org",
+              "organisationIdentifier": "24-3701590"
+            },
+            {
+              "contactInformation": [
+                {
+                  "addressLine1": "24 Sandbank rd",
+                  "addressLine2": "Sandbank",
+                  "addressLine3": "",
+                  "country": "United Kingdom",
+                  "county": "Down",
+                  "postCode": "BT21 525",
+                  "townCity": "Galway"
+                }
+              ],
+              "name": "0 Org",
+              "organisationIdentifier": "24-3701590"
+            },
+            {
+              "contactInformation": [
+                {
+                  "addressLine1": "24 Sandbank rd",
+                  "addressLine2": "Sandbank",
+                  "addressLine3": "",
+                  "country": "United Kingdom",
+                  "county": "Down",
+                  "postCode": "BT21 525",
+                  "townCity": "Galway"
+                }
+              ],
+              "name": "* Org",
+              "organisationIdentifier": "24-3701590"
             }
           ]);
         })
@@ -156,14 +276,89 @@ describe('organisationClient', () => {
       })
     });
 
-    test('it should return a list of organisations in alphabetical order (Ascending)', () => {
+    test('it should return a list of organisations when matching organisations are found in Ascending alphabetical order', () => {
       nock(mockUrl)
           .get(`/${mockStatus}?address=true`)
           .reply(200, fs.readFileSync(path.join(__dirname, 'mockResponseBody.json')))
 
-      return organisationClient.getOrganisationByName(mockStatus, 'inc')
+      return organisationClient.getOrganisationByName(mockStatus, 'org')
           .then(response => {
             expect(response).toEqual([
+              {
+                "contactInformation": [
+                  {
+                    "addressLine1": "24 Sandbank rd",
+                    "addressLine2": "Sandbank",
+                    "addressLine3": "",
+                    "country": "United Kingdom",
+                    "county": "Down",
+                    "postCode": "BT21 525",
+                    "townCity": "Galway"
+                  }
+                ],
+                "name": "* Org",
+                "organisationIdentifier": "24-3701590"
+              },
+              {
+                "contactInformation": [
+                  {
+                    "addressLine1": "24 Sandbank rd",
+                    "addressLine2": "Sandbank",
+                    "addressLine3": "",
+                    "country": "United Kingdom",
+                    "county": "Down",
+                    "postCode": "BT21 525",
+                    "townCity": "Galway"
+                  }
+                ],
+                "name": "0 Org",
+                "organisationIdentifier": "24-3701590"
+              },
+              {
+                "contactInformation": [
+                  {
+                    "addressLine1": "24 Sandbank rd",
+                    "addressLine2": "Sandbank",
+                    "addressLine3": "",
+                    "country": "United Kingdom",
+                    "county": "Down",
+                    "postCode": "BT21 525",
+                    "townCity": "Galway"
+                  }
+                ],
+                "name": "1 Org",
+                "organisationIdentifier": "24-3701590"
+              },
+              {
+                "contactInformation": [
+                  {
+                    "addressLine1": "24 Sandbank rd",
+                    "addressLine2": "Sandbank",
+                    "addressLine3": "",
+                    "country": "United Kingdom",
+                    "county": "Down",
+                    "postCode": "BT21 525",
+                    "townCity": "Galway"
+                  }
+                ],
+                "name": "2 Org",
+                "organisationIdentifier": "24-3701590"
+              },
+              {
+                "contactInformation": [
+                  {
+                    "addressLine1": "24 Sandbank rd",
+                    "addressLine2": "Sandbank",
+                    "addressLine3": "",
+                    "country": "United Kingdom",
+                    "county": "Down",
+                    "postCode": "BT21 525",
+                    "townCity": "Galway"
+                  }
+                ],
+                "name": "9 Org",
+                "organisationIdentifier": "24-3701590"
+              },
               {
                 "contactInformation": [
                   {
@@ -176,7 +371,7 @@ describe('organisationClient', () => {
                     "townCity": "Craigavon"
                   }
                 ],
-                "name": "Ernser Inc",
+                "name": "B Org",
                 "organisationIdentifier": "21-3701590"
               },
               {
@@ -191,7 +386,7 @@ describe('organisationClient', () => {
                     "townCity": "Galway"
                   }
                 ],
-                "name": "Kassulke Inc",
+                "name": "X Org",
                 "organisationIdentifier": "24-3701590"
               }
             ]);

--- a/__tests__/organisationClient.ts
+++ b/__tests__/organisationClient.ts
@@ -35,7 +35,7 @@ describe('organisationClient', () => {
                 }
               ],
               "name": "Ernser Inc",
-              "organisationIdentifier": "21-3701590"
+              "organisationIdentifier": "21-1111111"
             },
             {
               "contactInformation": [
@@ -50,7 +50,7 @@ describe('organisationClient', () => {
                 }
               ],
               "name": "Zboncak and Sons",
-              "organisationIdentifier": "25-3701590"
+              "organisationIdentifier": "22-2222222"
             },
             {
               "contactInformation": [
@@ -65,67 +65,67 @@ describe('organisationClient', () => {
                 }
               ],
               "name": "Kassulke Inc",
-              "organisationIdentifier": "24-3701590"
+              "organisationIdentifier": "23-3333333"
             },
             {
               "contactInformation": [
                 {
-                  "addressLine1": "1 Trasna way",
-                  "addressLine2": "Lurgan",
+                  "addressLine1": "1 This is the way",
+                  "addressLine2": "London",
                   "addressLine3": "",
                   "country": "United Kingdom",
-                  "county": "Armagh",
-                  "postCode": "BT25 545",
-                  "townCity": "Craigavon"
+                  "county": "Westminster",
+                  "postCode": "XW16 5AA",
+                  "townCity": "London"
                 }
               ],
               "name": "B Org",
-              "organisationIdentifier": "21-3701590"
+              "organisationIdentifier": "24-4444444"
             },
             {
               "contactInformation": [
                 {
-                  "addressLine1": "10 Lakeview",
+                  "addressLine1": "12 Lakeview",
                   "addressLine2": "Crumlin",
                   "addressLine3": "",
                   "country": "United Kingdom",
                   "county": "Down",
-                  "postCode": "BT21 525",
+                  "postCode": "BT21 G25",
                   "townCity": "Ballymena"
                 }
               ],
               "name": "Z and Sons",
-              "organisationIdentifier": "25-3701590"
+              "organisationIdentifier": "25-5555555"
             },
             {
               "contactInformation": [
                 {
-                  "addressLine1": "24 Sandbank rd",
-                  "addressLine2": "Sandbank",
+                  "addressLine1": "24 Mountain rd",
+                  "addressLine2": "Hideban,",
                   "addressLine3": "",
                   "country": "United Kingdom",
                   "county": "Down",
-                  "postCode": "BT21 525",
-                  "townCity": "Galway"
+                  "postCode": "BT18 7DU",
+                  "townCity": "Belfast"
                 }
               ],
               "name": "X Org",
-              "organisationIdentifier": "24-3701590"
+              "organisationIdentifier": "26-6666666"
             },
             {
               "contactInformation": [
                 {
-                  "addressLine1": "24 Sandbank rd",
-                  "addressLine2": "Sandbank",
+                  "addressLine1": "64 Zoo lane",
+                  "addressLine2": "On the Hikk",
                   "addressLine3": "",
                   "country": "United Kingdom",
                   "county": "Down",
-                  "postCode": "BT21 525",
+                  "postCode": "BT21 6JE",
                   "townCity": "Galway"
                 }
               ],
               "name": "1 Org",
-              "organisationIdentifier": "24-3701590"
+              "organisationIdentifier": "27-7777777"
             },
             {
               "contactInformation": [
@@ -140,7 +140,7 @@ describe('organisationClient', () => {
                 }
               ],
               "name": "2 Org",
-              "organisationIdentifier": "24-3701590"
+              "organisationIdentifier": "24-1238393"
             },
             {
               "contactInformation": [
@@ -155,7 +155,7 @@ describe('organisationClient', () => {
                 }
               ],
               "name": "9 Org",
-              "organisationIdentifier": "24-3701590"
+              "organisationIdentifier": "24-1238333"
             },
             {
               "contactInformation": [
@@ -170,7 +170,7 @@ describe('organisationClient', () => {
                 }
               ],
               "name": "0 Org",
-              "organisationIdentifier": "24-3701590"
+              "organisationIdentifier": "24-4827328"
             },
             {
               "contactInformation": [
@@ -185,7 +185,7 @@ describe('organisationClient', () => {
                 }
               ],
               "name": "* Org",
-              "organisationIdentifier": "24-3701590"
+              "organisationIdentifier": "24-2847729"
             }
           ]);
         })
@@ -255,7 +255,7 @@ describe('organisationClient', () => {
               }
             ],
             "name": "Ernser Inc",
-            "organisationIdentifier": "21-3701590"
+            "organisationIdentifier": "21-1111111"
           },
           {
             "contactInformation": [
@@ -270,7 +270,7 @@ describe('organisationClient', () => {
               }
             ],
             "name": "Kassulke Inc",
-            "organisationIdentifier": "24-3701590"
+            "organisationIdentifier": "23-3333333"
           }
         ]);
       })
@@ -297,7 +297,7 @@ describe('organisationClient', () => {
                   }
                 ],
                 "name": "* Org",
-                "organisationIdentifier": "24-3701590"
+                "organisationIdentifier": "24-2847729"
               },
               {
                 "contactInformation": [
@@ -312,22 +312,22 @@ describe('organisationClient', () => {
                   }
                 ],
                 "name": "0 Org",
-                "organisationIdentifier": "24-3701590"
+                "organisationIdentifier": "24-4827328"
               },
               {
                 "contactInformation": [
                   {
-                    "addressLine1": "24 Sandbank rd",
-                    "addressLine2": "Sandbank",
+                    "addressLine1": "64 Zoo lane",
+                    "addressLine2": "On the Hikk",
                     "addressLine3": "",
                     "country": "United Kingdom",
                     "county": "Down",
-                    "postCode": "BT21 525",
+                    "postCode": "BT21 6JE",
                     "townCity": "Galway"
                   }
                 ],
                 "name": "1 Org",
-                "organisationIdentifier": "24-3701590"
+                "organisationIdentifier": "27-7777777"
               },
               {
                 "contactInformation": [
@@ -342,7 +342,7 @@ describe('organisationClient', () => {
                   }
                 ],
                 "name": "2 Org",
-                "organisationIdentifier": "24-3701590"
+                "organisationIdentifier": "24-1238393"
               },
               {
                 "contactInformation": [
@@ -357,37 +357,37 @@ describe('organisationClient', () => {
                   }
                 ],
                 "name": "9 Org",
-                "organisationIdentifier": "24-3701590"
+                "organisationIdentifier": "24-1238333"
               },
               {
                 "contactInformation": [
                   {
-                    "addressLine1": "1 Trasna way",
-                    "addressLine2": "Lurgan",
+                    "addressLine1": "1 This is the way",
+                    "addressLine2": "London",
                     "addressLine3": "",
                     "country": "United Kingdom",
-                    "county": "Armagh",
-                    "postCode": "BT25 545",
-                    "townCity": "Craigavon"
+                    "county": "Westminster",
+                    "postCode": "XW16 5AA",
+                    "townCity": "London"
                   }
                 ],
                 "name": "B Org",
-                "organisationIdentifier": "21-3701590"
+                "organisationIdentifier": "24-4444444"
               },
               {
                 "contactInformation": [
                   {
-                    "addressLine1": "24 Sandbank rd",
-                    "addressLine2": "Sandbank",
+                    "addressLine1": "24 Mountain rd",
+                    "addressLine2": "Hideban,",
                     "addressLine3": "",
                     "country": "United Kingdom",
                     "county": "Down",
-                    "postCode": "BT21 525",
-                    "townCity": "Galway"
+                    "postCode": "BT18 7DU",
+                    "townCity": "Belfast"
                   }
                 ],
                 "name": "X Org",
-                "organisationIdentifier": "24-3701590"
+                "organisationIdentifier": "26-6666666"
               }
             ]);
           })

--- a/src/organisationClient.ts
+++ b/src/organisationClient.ts
@@ -36,6 +36,10 @@ export class OrganisationClient {
 
     name = name.trim().toLowerCase();
 
+    const alphabeticalOrder = () =>
+        (organisationOne: { name: string; }, organisationsTwo: { name: string; }) =>
+        organisationOne.name.localeCompare(organisationsTwo.name);
+
     return this.getOrganisations(status, address)
       .then(organisations => {
         return organisations.filter(organisation => {
@@ -43,8 +47,7 @@ export class OrganisationClient {
             .trim()
             .toLowerCase()
             .includes(name);
-        }).sort((organisationOne, organisationsTwo) =>
-            organisationOne.name.localeCompare(organisationsTwo.name))
+        }).sort(alphabeticalOrder())
       })
       .catch(error => { throw error });
   }

--- a/src/organisationClient.ts
+++ b/src/organisationClient.ts
@@ -43,12 +43,13 @@ export class OrganisationClient {
             .trim()
             .toLowerCase()
             .includes(name);
-        })
+        }).sort((organisationOne, organisationsTwo) =>
+            organisationOne.name.localeCompare(organisationsTwo.name))
       })
-      .catch(error => { throw error });        
+      .catch(error => { throw error });
   }
 
-  private getUri(path: string): Promise<any> {  
+  private getUri(path: string): Promise<any> {
     return fetch(`${this.apiUrl}${path}`, {
       headers: {
         'Authorization': this.apiKey,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DIV-6825

### Change description ###

When filter in prd-client we need to return list of organisations in alphabetical order (by name only).
Should return list of org in alphabetical order.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
