### PR TITLE
Responbility added to the client to format auth header rather than co…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/prd-client",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Client library to access Professional Reference Data",
   "files": [
     "lib"

--- a/src/organisationClient.ts
+++ b/src/organisationClient.ts
@@ -55,7 +55,7 @@ export class OrganisationClient {
   private getUri(path: string): Promise<any> {
     return fetch(`${this.apiUrl}${path}`, {
       headers: {
-        'Authorization': this.apiKey,
+        'Authorization': `Bearer ${this.apiKey}`,
         'ServiceAuthorization': this.serviceApiKey,
         'accept': 'application/json'
       }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

### Change description ###
Client now prepends 'Bearer' to the Auth header rather than relying on consumer.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
